### PR TITLE
Fix typo in Links documentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-responses-document",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-responses-document",
   "description": "A documentation for method responses based on AMF model",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "license": "Apache-2.0",
   "main": "api-responses-document.js",
   "keywords": [

--- a/src/ApiLinksDocument.js
+++ b/src/ApiLinksDocument.js
@@ -44,7 +44,7 @@ export class ApiLinksDocument extends AmfHelperMixin(LitElement) {
     }
     return html`
     <div class="operation-id">
-      <span class="label">Opeartion ID:</span>
+      <span class="label">Operation ID:</span>
       <span class="operation-name">${opId}</span>
     </div>
     `;


### PR DESCRIPTION
Fix minor typo in Links documentation: Opeartion ID
![image](https://user-images.githubusercontent.com/24916481/85134029-336a9580-b212-11ea-82eb-9625e8513c24.png)
