### PR TITLE
Fix/apic 335

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-responses-document",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-responses-document",
   "description": "A documentation for method responses based on AMF model",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "license": "Apache-2.0",
   "main": "api-responses-document.js",
   "keywords": [

--- a/src/ApiResponsesDocument.js
+++ b/src/ApiResponsesDocument.js
@@ -323,6 +323,7 @@ export class ApiResponsesDocument extends AmfHelperMixin(LitElement) {
     return html`
     <div class="codes-selector">
       <anypoint-tabs
+        scrollable
         .selected="${selected}"
         ?compatibility="${this.compatibility}"
         @selected-changed="${this._tabsHandler}">

--- a/test/api-responses-document.test.js
+++ b/test/api-responses-document.test.js
@@ -115,6 +115,10 @@ describe('<api-responses-document>', function() {
           assert.equal(nodes[2].innerText.trim(), '400',  '400 status is rendered');
         });
 
+        it('renders anypoint-tabs with scrollable', () => {
+          assert.isTrue(element.shadowRoot.querySelector('anypoint-tabs').scrollable);
+        });
+
         it('selected is computed', () => {
           assert.deepEqual(element.selected, 0);
         });


### PR DESCRIPTION
When there are too many response codes defined, the list cannot be scrolled.
![image-2020-05-19-21-53-30-008](https://user-images.githubusercontent.com/13999213/86953505-e9971000-c12a-11ea-96a3-4cebbb25a57d.png)

fix: add _scrollable_ property to anypoint-tabs
