### PR TITLE
Fix/code tabs divider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-responses-document",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-responses-document",
   "description": "A documentation for method responses based on AMF model",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ApiResponsesDocument.js
+++ b/src/ApiResponsesDocument.js
@@ -321,6 +321,7 @@ export class ApiResponsesDocument extends AmfHelperMixin(LitElement) {
         @selected-changed="${this._tabsHandler}">
         ${codes.map((item) => html`<anypoint-tab>${item}</anypoint-tab>`)}
       </anypoint-tabs>
+      <div class="codes-selector-divider"></div>
     </div>`;
   }
 

--- a/src/Styles.js
+++ b/src/Styles.js
@@ -14,7 +14,8 @@ arc-marked {
   font-style: italic;
 }
 
-.codes-selector {
+.codes-selector-divider {
+  margin: 0 50px;
   border-bottom: 1px #e5e5e5 solid;
 }
 


### PR DESCRIPTION
Line dividing code tabs from code response documentation should not include scroll caret icons.